### PR TITLE
Remove UUID from command line

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,29 +9,31 @@ Source a new environment and install dependencies:
 
     virtualenv -p python3.6 v3nv && . v3nv/bin/activate && pip install -r requirements.txt
 
-Parse the xlsx and include a project uuid:
+Parse the xlsx:
 
     #!/usr/bin/env bash
 
     # E-GEOD-81547_curated_ontologies_07_2019.xlsx
-    python xlsx_to_project_json.py --uuid cddab57b-6868-4be4-806f-395ed9dd635a --xlsx data/test_000.xlsx
+    python xlsx_to_project_json.py --xlsx data/test_000.xlsx
     
     # Gary_Bader_9_16.xlsx
-    python xlsx_to_project_json.py --uuid 4d6f6c96-2a83-43d8-8fe1-0f53bffd4674 --xlsx data/test_001.xlsx
+    python xlsx_to_project_json.py --xlsx data/test_001.xlsx
     
     # GEOD-93593_HCA_Ontologies_July_2.xlsx
-    python xlsx_to_project_json.py --uuid 2043c65a-1cf8-4828-a656-9e247d4e64f1 --xlsx data/test_002.xlsx
+    python xlsx_to_project_json.py --xlsx data/test_002.xlsx
     
     # hca-metadata-spreadsheet-GSE84133_pancreas.xlsx
-    python xlsx_to_project_json.py --uuid f86f1ab4-1fbb-4510-ae35-3ffd752d4dfc --xlsx data/test_003.xlsx
+    python xlsx_to_project_json.py --xlsx data/test_003.xlsx
     
     # hca-metadata-spreadsheet-GSE95459-GSE114374-colon.xlsx
-    python xlsx_to_project_json.py --uuid f8aa201c-4ff1-45a4-890e-840d63459ca2 --xlsx data/test_004.xlsx
+    python xlsx_to_project_json.py --xlsx data/test_004.xlsx
     
     # mf-E-GEOD-106540_spreadsheet_v9.xlsx
-    python xlsx_to_project_json.py --uuid 90bd6933-40c0-48d4-8d76-778c103bf545 --xlsx data/test_005.xlsx
+    python xlsx_to_project_json.py --xlsx data/test_005.xlsx
 
 Adding `--upload true` will upload the data to the DSS.
+Note that UUID's are now always programmatically generated from GEO accessions 
+and cannot be provided via the commandline.
 
 **NOTE**:
 

--- a/run_all.py
+++ b/run_all.py
@@ -19,15 +19,12 @@ Editing 'upload=False' to 'upload=True' with upload to dss dev if you are creden
 Otherwise it will just parse the excel files and generate all of the matrix and json files necessary for upload.
 """
 
-# uuid only doesn't matter if "upload=False" and useful for testing the parser portion only.
-
 """6 ORIGINAL DATASETS (ALREADY IN THE DSS)"""
 # These are the original excel files provided that currently exist in dss prod
 # and we have finished examples to compare against.
 for project in range(6):
     print(f'\nProject: test_00{project}')
-    run(str(uuid4()),
-        xlsx=f'data/test_00{project}.xlsx',
+    run(xlsx=f'data/test_00{project}.xlsx',
         output_dir=f'testing_comparison/test_00{project}',
         upload=False)
 
@@ -44,7 +41,6 @@ projects = [f for f in os.listdir(src_dir) if os.path.isfile(os.path.join(src_di
 
 for project in projects:
     print(f'\nProject: {project}')
-    run(str(uuid4()),
-        xlsx=f'raw_excel_inputs/{project}',
+    run(xlsx=f'raw_excel_inputs/{project}',
         output_dir=f'testing_comparison/{project[:-5]}',
         upload=False)


### PR DESCRIPTION
Project UUID generation must always be deterministic and consistent. I need to be able to independently derive project UUIDs for the filenames of generated summary figures such as tSNE. These changes force project UUIDs to always be deterministically generated by removing the option to provide one via the commandline.