### PR TITLE
Update Make to allow pushing prod data.

### DIFF
--- a/.attic/prep_prod_bundles.py
+++ b/.attic/prep_prod_bundles.py
@@ -1,0 +1,98 @@
+from datetime import datetime
+import json
+import os
+import uuid
+
+
+# TODO: Consolidate similar functions and clean up code.
+
+
+def timestamp():
+    return datetime.utcnow().strftime("%Y-%m-%dT%H%M%S.%fZ")
+
+
+good_timestamp = timestamp()
+
+
+def generate_file_uuid(bundle_uuid: str, file_name: str) -> str:
+    """
+    Deterministically generate a file UUID based on the parent bundle uuid and its file name.
+    """
+    namespace_uuid = uuid.UUID('4c52e3d0-ffe5-4b4d-a4d0-cb6a6f372b31')
+    return str(uuid.uuid5(namespace_uuid, bundle_uuid + file_name))
+
+
+def get_cell_count(project_uuid):
+    with open('/home/quokka/yeah/load-project/.attic/prod_cell_counts.json', 'r') as f:
+        counts = json.load(f)
+    return counts[project_uuid]['cell_count']
+
+
+def update_fields(file, filename, bundle_uuid, cell_count, project_uuid=None):
+    with open(file, 'r') as f1:
+        update = json.loads(f1.read())
+
+    if filename != 'links.json':
+        update['provenance']['document_id'] = project_uuid if project_uuid else generate_file_uuid(bundle_uuid, filename)
+        update['provenance']['submission_date'] = good_timestamp
+        update['provenance']['update_date'] = good_timestamp
+
+    if filename == 'cell_suspension_0.json':
+        update['estimated_cell_count'] = cell_count
+
+    with open(file, 'w') as f1:
+        f1.write(json.dumps(dict(update), indent=4))
+
+
+def generate_analysis_json(bundle_uuid, output_dir):
+    file_name = 'analysis_file_0.json'
+    version = timestamp()
+    analysis_json = {
+        "describedBy": "https://schema.humancellatlas.org/type/file/6.0.0/analysis_file",
+        "file_core": {
+            "file_name": "matrix.mtx.zip",
+            "format": "mtx"
+        },
+        "schema_type": "file",
+        "provenance": {
+            "document_id": generate_file_uuid(bundle_uuid, file_name),
+            "submission_date": version,  # TODO: Fetch from DSS if it exists
+            "update_date": version
+        }
+    }
+    with open(f'{output_dir}/{file_name}', 'w') as f:
+        f.write(json.dumps(analysis_json, indent=4))
+    print(f'"{output_dir}/{file_name}" successfully written.')
+
+
+for root, dirs, _ in os.walk('/home/quokka/yeah/load-project/projects'):
+    for d in dirs:
+        project_folder = os.path.join(root, d)
+
+        if len(d) ==len('4c52e3d0-ffe5-4b4d-a4d0-cb6a6f372b31'):
+            cell_count = get_cell_count(d)
+            assert cell_count > 1
+            for sub_root, _, files in os.walk(project_folder):
+                for f in files:
+                    file = os.path.join(sub_root, f)
+                    if f == 'bundle.json' or f.startswith('sequence_file'):
+                        print(f'Deleting: {file}')
+                        os.remove(file)
+                    elif f == 'links.json':
+                        with open(file, 'w') as f1:
+                            f1.write(json.dumps({
+                                "describedBy": "https://schema.humancellatlas.org/system/1.1.5/links",
+                                "schema_type": "link_bundle",
+                                "schema_version": "1.1.5",
+                                "links": []}, indent=4))
+                    elif f.startswith('project_0.json'):
+                        print(f'Updating: {file}')
+                        update_fields(file=file, filename=f, bundle_uuid=d, cell_count=cell_count, project_uuid=d)
+                    elif f.endswith('.json'):
+                        print(f'Updating: {file}')
+                        print(f'{f}: {cell_count}')
+                        update_fields(file=file, filename=f, bundle_uuid=d, cell_count=cell_count)
+
+            matrix_file = os.path.join(project_folder, 'bundle', 'matrix.mtx.zip')
+            if os.path.exists(matrix_file):
+                generate_analysis_json(bundle_uuid=d, output_dir=os.path.join(project_folder, 'bundle'))

--- a/.attic/prep_prod_bundles.py
+++ b/.attic/prep_prod_bundles.py
@@ -29,16 +29,21 @@ def get_cell_count(project_uuid):
 
 
 def update_fields(file, filename, bundle_uuid, cell_count, project_uuid=None):
+    project_uuid = project_uuid if project_uuid else generate_file_uuid(bundle_uuid, filename)
     with open(file, 'r') as f1:
         update = json.loads(f1.read())
 
-    if filename != 'links.json':
-        update['provenance']['document_id'] = project_uuid if project_uuid else generate_file_uuid(bundle_uuid, filename)
+    if filename not in ('links.json', 'cell_suspension_0.json'):
+        update['provenance']['document_id'] = project_uuid
         update['provenance']['submission_date'] = good_timestamp
         update['provenance']['update_date'] = good_timestamp
 
     if filename == 'cell_suspension_0.json':
         update['estimated_cell_count'] = cell_count
+        update['describedBy'] = 'https://schema.dev.data.humancellatlas.org/type/biomaterial/13.1.0/cell_suspension'
+        update['provenance'] = {'document_id': project_uuid,
+                                'submission_date': good_timestamp,
+                                'update_date': good_timestamp}
 
     with open(file, 'w') as f1:
         f1.write(json.dumps(dict(update), indent=4))
@@ -46,7 +51,6 @@ def update_fields(file, filename, bundle_uuid, cell_count, project_uuid=None):
 
 def generate_analysis_json(bundle_uuid, output_dir):
     file_name = 'analysis_file_0.json'
-    version = timestamp()
     analysis_json = {
         "describedBy": "https://schema.humancellatlas.org/type/file/6.0.0/analysis_file",
         "file_core": {
@@ -56,8 +60,8 @@ def generate_analysis_json(bundle_uuid, output_dir):
         "schema_type": "file",
         "provenance": {
             "document_id": generate_file_uuid(bundle_uuid, file_name),
-            "submission_date": version,  # TODO: Fetch from DSS if it exists
-            "update_date": version
+            "submission_date": good_timestamp,  # TODO: Fetch from DSS if it exists
+            "update_date": good_timestamp
         }
     }
     with open(f'{output_dir}/{file_name}', 'w') as f:
@@ -69,13 +73,15 @@ for root, dirs, _ in os.walk('/home/quokka/yeah/load-project/projects'):
     for d in dirs:
         project_folder = os.path.join(root, d)
 
-        if len(d) ==len('4c52e3d0-ffe5-4b4d-a4d0-cb6a6f372b31'):
+        if len(d) == len('4c52e3d0-ffe5-4b4d-a4d0-cb6a6f372b31'):
             cell_count = get_cell_count(d)
             assert cell_count > 1
             for sub_root, _, files in os.walk(project_folder):
                 for f in files:
                     file = os.path.join(sub_root, f)
-                    if f == 'bundle.json' or f.startswith('sequence_file'):
+                    if f == 'bundle.json' \
+                            or f.startswith('sequence_file') \
+                            or (f.startswith('cell_suspension') and f != 'cell_suspension_0.json'):
                         print(f'Deleting: {file}')
                         os.remove(file)
                     elif f == 'links.json':

--- a/.attic/prod_cell_counts.json
+++ b/.attic/prod_cell_counts.json
@@ -1,0 +1,179 @@
+{
+    "cddab57b-6868-4be4-806f-395ed9dd635a": {
+        "project_manifest": "",
+        "cell_count": 2544,
+        "compare": "with our actual counts from geo"
+    },
+    "4d6f6c96-2a83-43d8-8fe1-0f53bffd4674": {
+        "project_manifest": "",
+        "cell_count": 30000,
+        "compare": "with our actual counts from geo"
+    },
+    "2043c65a-1cf8-4828-a656-9e247d4e64f1": {
+        "project_manifest": "",
+        "cell_count": 1733,
+        "was": "unspecified",
+        "compare": "with our actual counts from geo"
+    },
+    "f86f1ab4-1fbb-4510-ae35-3ffd752d4dfc": {
+        "project_manifest": "",
+        "cell_count": 12404,
+        "compare": "with our actual counts from geo"
+    },
+    "f8aa201c-4ff1-45a4-890e-840d63459ca2": {
+        "project_manifest": "",
+        "cell_count": 16893,
+        "compare": "with our actual counts from geo"
+    },
+    "90bd6933-40c0-48d4-8d76-778c103bf545": {
+        "project_manifest": "",
+        "cell_count": 2244,
+        "compare": "with our actual counts from geo"
+    },
+    "8185730f-4113-40d3-9cc3-929271784c2b": {
+        "project_manifest": "c36973e8-c51e-588e-a18a-94b8c6bb2069.tsv",
+        "cell_count": 44000,
+        "bundle_uuid": "b6f23f10-cceb-4606-9ed0-5f3f3f63ba6f",
+        "mtx": true
+    },
+    "005d611a-14d5-4fbf-846e-571a1f874f70": {
+        "project_manifest": "3d7d9d53-3a23-575b-8655-71f4b58bc6bf.tsv",
+        "cell_count": 19916,
+        "bundle_uuid": "95c479cb-ce2a-4e66-bce3-e94e362284c6",
+        "mtx": true
+    },
+    "a29952d9-925e-40f4-8a1c-274f118f1f51": {
+        "project_manifest": "a4e8ffa3-2167-5882-a42a-6478af16c677.tsv",
+        "cell_count": 9500,
+        "bundle_uuid": "38414e2c-090b-48b9-bf2d-16659899ab93",
+        "mtx": false
+    },
+    "f81efc03-9f56-4354-aabb-6ce819c3d414": {
+        "project_manifest": "34fe2d4f-6fb0-5709-a65e-e276a6b195b6.tsv",
+        "cell_count": 20000,
+        "bundle_uuid": "45ab2fbd-e6ab-4aaf-9044-b6c11ab93706",
+        "mtx": false
+    },
+    "cc95ff89-2e68-4a08-a234-480eca21ce79": {
+        "project_manifest": "da81bb40-4ddc-5fde-8ca9-55aa1d10d679.tsv",
+        "cell_count": 528092,
+        "bundle_uuid": "0eaa712a-bb35-4b36-be51-7a4b9a19f9d6",
+        "mtx": true
+    },
+    "c4077b3c-5c98-4d26-a614-246d12c2e5d7": {
+        "project_manifest": "0cca81fc-d877-5d1c-b6b4-5b91a2167ced.tsv",
+        "cell_count": 199845,
+        "bundle_uuid": "64c857ab-3fef-45ec-955f-98a7b2b03f65",
+        "mtx": true
+    },
+    "091cf39b-01bc-42e5-9437-f419a66c8a45": {
+        "project_manifest": "05797e3c-86ab-598b-a623-ec7030218dc3.tsv",
+        "cell_count": 1480000,
+        "bundle_uuid": "8496f742-25d2-425a-b262-87d903c289ae",
+        "mtx": true
+    },
+    "027c51c6-0719-469f-a7f5-640fe57cbece": {
+        "project_manifest": "7c71d75d-23a8-5d6f-90a5-07493143c9ea.tsv",
+        "cell_count": 4000,
+        "bundle_uuid": "8d15738a-a26d-42e7-97d4-0e4c83a72d10",
+        "mtx": false
+    },
+    "ae71be1d-ddd8-4feb-9bed-24c3ddb6e1ad": {
+        "project_manifest": "4f9b3823-1544-595c-a45f-4f2d0aea1c4a.tsv",
+        "cell_count": 3514,
+        "bundle_uuid": "0e704d02-4035-41c0-86b5-5096b1bd40a9",
+        "mtx": false
+    },
+    "88ec040b-8705-4f77-8f41-f81e57632f7d": {
+        "project_manifest": "5c4e39ab-90ac-5d84-b9d3-7c20b54d4863.tsv",
+        "cell_count": 59780,
+        "bundle_uuid": "5822b076-cf01-4568-bd80-feb75b37b5e3",
+        "mtx": false
+    },
+    "577c946d-6de5-4b55-a854-cd3fde40bff2": {
+        "project_manifest": "dffda4c2-286c-500d-8784-1b3b4470272b.tsv",
+        "cell_count": 30000,
+        "bundle_uuid": "76bc5307-a8d9-44ca-a32f-72a6865c67d5",
+        "mtx": false
+    },
+    "9c20a245-f2c0-43ae-82c9-2232ec6b594f": {
+        "project_manifest": "41139e67-4c5d-5ccb-b407-aa11f22cdf49.tsv",
+        "cell_count": 230800,
+        "bundle_uuid": "792d0b2d-8d8f-47e4-ac94-cca644140812",
+        "mtx": false
+    },
+    "74b6d569-3b11-42ef-b6b1-a0454522b4a0": {
+        "project_manifest": "358b4817-eb60-5bc7-9d69-4e772888cf91.tsv",
+        "cell_count": 1330000,
+        "bundle_uuid": "2574757a-b62f-4ab3-ae83-1219ad2d03c6",
+        "mtx": false
+    },
+    "1defdada-a365-44ad-9b29-443b06bd11d6": {
+        "project_manifest": "d1513895-3a09-5610-8451-6aff80cc3d64.tsv",
+        "cell_count": 339089,
+        "bundle_uuid": "0fbc2a3a-fbb7-41b1-b6b2-9602f39fdbc8",
+        "mtx": false
+    },
+    "4e6f083b-5b9a-4393-9890-2a83da8188f1": {
+        "project_manifest": "535560f1-9456-53b0-ab8a-946431c4fd83.tsv",
+        "cell_count": 112201,
+        "bundle_uuid": "1c460b84-d09c-4d4e-be0e-ea9b2eed1b46",
+        "mtx": false
+    },
+    "8c3c290d-dfff-4553-8868-54ce45f4ba7f": {
+        "project_manifest": "cf9a8385-3d13-51c2-bdd2-e5140b07c6d4.tsv",
+        "cell_count": 6639,
+        "bundle_uuid": "05b5e0bd-811c-4c29-a71b-b6a9814cbc4c",
+        "mtx": false
+    },
+    "e0009214-c0a0-4a7b-96e2-d6a83e966ce0": {
+        "project_manifest": "9a738660-c43e-5648-b301-57c65f076a6f.tsv",
+        "cell_count": 48977,
+        "this": "needs to be actually checked; tabula muris says 100k+ cells.",
+        "bundle_uuid": "13887894-c484-49d3-a778-4fa450d90a10",
+        "mtx": false
+    },
+    "116965f3-f094-4769-9d28-ae675c1b569c": {
+        "project_manifest": "499ffd25-58ed-5eaa-86b2-82a9a4167aff.tsv",
+        "cell_count": 15744,
+        "was": "unspecified",
+        "bundle_uuid": "c6633095-68f9-4118-981b-16dc8b42a5a1",
+        "mtx": true
+    },
+    "4a95101c-9ffc-4f30-a809-f04518a23803": {
+        "project_manifest": "f20e2ccb-93fb-5c70-800f-e664aaa44890.tsv",
+        "cell_count": 267360,
+        "was": "unspecified",
+        "bundle_uuid": "f3b7ca6b-84a3-43ba-afad-a78beae7c927",
+        "mtx": true
+    },
+    "f83165c5-e2ea-4d15-a5cf-33f3550bffde": {
+        "project_manifest": "ffa646c1-61fc-5456-a488-0ddf4324a0d6.tsv",
+        "cell_count": 546183,
+        "was": "unspecified",
+        "bundle_uuid": "256408e8-fe91-4976-bca9-9389089b35a7",
+        "mtx": true
+    },
+    "abe1a013-af7a-45ed-8c26-f3793c24a1f4": {
+        "project_manifest": "a2186fbc-1d18-5d07-ade5-00b0c33b570e.tsv",
+        "cell_count": 341079,
+        "was": "unspecified",
+        "bundle_uuid": "05a28b33-ae4e-465d-9c81-d98d95d3765c",
+        "mtx": true
+    },
+    "a9c022b4-c771-4468-b769-cabcf9738de3": {
+        "project_manifest": "125e57e7-7f61-5120-a282-68d18aa30a35.tsv",
+        "cell_count": 40993,
+        "was": "unspecified",
+        "bundle_uuid": "0dbe4b76-114f-4e0f-864c-7fd367c6da01",
+        "mtx": false
+    },
+    "008e40e8-66ae-43bb-951c-c073a2fa6774": {
+        "project_manifest": "e9f3855d-63d5-5513-957e-15baf891912c.tsv",
+        "cell_count": 114,
+        "was": "unspecified",
+        "this": "needs to be actually checked",
+        "bundle_uuid": "0ec17a59-3c4e-43a3-aaa7-6d5bcb2a75b5",
+        "mtx": false
+    }
+}

--- a/.attic/prod_cell_counts.json
+++ b/.attic/prod_cell_counts.json
@@ -2,32 +2,50 @@
     "cddab57b-6868-4be4-806f-395ed9dd635a": {
         "project_manifest": "",
         "cell_count": 2544,
+        "GEO": "GSE81547",
+        "new_uuid": "bd4ebaac-7bcb-5069-b3ea-3a13887092e8",
+        "mtx": true,
         "compare": "with our actual counts from geo"
     },
     "4d6f6c96-2a83-43d8-8fe1-0f53bffd4674": {
         "project_manifest": "",
         "cell_count": 30000,
+        "GEO": "GSE115469",
+        "new_uuid": "bdfe2399-b8a6-5b6a-9f0a-a5fd81d08ff4",
+        "mtx": true,
         "compare": "with our actual counts from geo"
     },
     "2043c65a-1cf8-4828-a656-9e247d4e64f1": {
         "project_manifest": "",
         "cell_count": 1733,
+        "GEO": "GSE93593",
+        "new_uuid": "99ab18ff-ca15-5d7d-9c2d-5c0b537fb1c2",
+        "mtx": true,
         "was": "unspecified",
         "compare": "with our actual counts from geo"
     },
     "f86f1ab4-1fbb-4510-ae35-3ffd752d4dfc": {
         "project_manifest": "",
         "cell_count": 12404,
+        "GEO": "GSE84133",
+        "new_uuid": "c366f1f5-27aa-5157-a142-110e492a3e52",
+        "mtx": false,
         "compare": "with our actual counts from geo"
     },
     "f8aa201c-4ff1-45a4-890e-840d63459ca2": {
         "project_manifest": "",
         "cell_count": 16893,
+        "GEO": "GSE114374",
+        "new_uuid": "b4b128d5-61e5-510e-9d91-a151b94fbb99",
+        "mtx": true,
         "compare": "with our actual counts from geo"
     },
     "90bd6933-40c0-48d4-8d76-778c103bf545": {
         "project_manifest": "",
         "cell_count": 2244,
+        "GEO": "GSE106540",
+        "new_uuid": "dd761426-cc9c-5fbd-8bec-93a4cc4eb999",
+        "mtx": false,
         "compare": "with our actual counts from geo"
     },
     "8185730f-4113-40d3-9cc3-929271784c2b": {

--- a/convert_matrices.py
+++ b/convert_matrices.py
@@ -25,6 +25,8 @@ from csv2mtx import (
     RowFilter,
     convert_csv_to_mtx,
 )
+from copy_static_project import link_project_metadata
+from generate_metadata import static_prod_bundles
 from h5_to_mtx import convert_h5_to_mtx
 from util import (
     get_target_project_dirs,
@@ -1789,9 +1791,15 @@ def main(project_dirs: List[Path]):
         else:
             for class_name, class_obj in converter_classes.items():
                 log.warning('Unused converter `%s` with UUID `%s`', class_obj.__doc__.strip())
-        print_projects('not implemented', not_implemented_projects, file=sys.stderr)
-        print_projects('failed', failed_projects, file=sys.stderr)
-        print_projects('succeeded', succeeded_projects)
+
+    for bundle in static_prod_bundles:
+        src_dir = Path('projects') / bundle
+        print(f'Hard-linked project ("*.mtx.zip" only) contents: {bundle}/hca to {bundle}/bundle.')
+        link_project_metadata(str(src_dir), file_pattern='*.mtx.zip')
+
+    print_projects('not implemented', not_implemented_projects, file=sys.stderr)
+    print_projects('failed', failed_projects, file=sys.stderr)
+    print_projects('succeeded', succeeded_projects)
 
 
 def print_projects(title, projects, file=None):

--- a/convert_matrices.py
+++ b/convert_matrices.py
@@ -1075,6 +1075,9 @@ class GSE93593(Converter):
 
     def _convert(self):
         # ignoring GSE93593_tpm.csv.gz
+
+        # This is a prod project that has a matrix already:
+        # https://data.humancellatlas.org/explore/projects/2043c65a-1cf8-4828-a656-9e247d4e64f1/expression-matrices
         self._convert_matrices(
             CSV('GSE93593_counts.csv.gz')
         )
@@ -1315,6 +1318,8 @@ class GSE114374(Converter):
     """
 
     def _convert(self):
+        # This is a prod project that has matrices already:
+        # https://data.humancellatlas.org/explore/projects/f8aa201c-4ff1-45a4-890e-840d63459ca2/expression-matrices
         self._convert_matrices(
             CSV('GSE114374_Human_HC_expression_matrix.txt.gz', sep='\t', row_filter=self._fix_short_rows(4379)),
             CSV('GSE114374_Human_UC_expression_matrix.txt.gz', sep='\t', row_filter=self._fix_short_rows(4904)),
@@ -1403,6 +1408,8 @@ class GSE81547(Converter):
     """
 
     def _convert(self):
+        # This is a prod project that has a matrix already:
+        # https://data.humancellatlas.org/explore/projects/cddab57b-6868-4be4-806f-395ed9dd635a/expression-matrices
         raise PostponedImplementationError('https://github.com/DailyDreaming/load-project/issues/43')
 
 
@@ -1412,6 +1419,8 @@ class GSE115469(Converter):
     """
 
     def _convert(self):
+        # This is a prod project that has a matrix already:
+        # https://data.humancellatlas.org/explore/projects/4d6f6c96-2a83-43d8-8fe1-0f53bffd4674/expression-matrices
         self._convert_matrices(
             CSV('GSE115469_Data.csv.gz')
         )

--- a/convert_matrices.py
+++ b/convert_matrices.py
@@ -25,8 +25,7 @@ from csv2mtx import (
     RowFilter,
     convert_csv_to_mtx,
 )
-from copy_static_project import link_project_metadata
-from generate_metadata import static_prod_bundles
+from copy_static_project import populate_all_static_projects
 from h5_to_mtx import convert_h5_to_mtx
 from util import (
     get_target_project_dirs,
@@ -1764,13 +1763,6 @@ class GSE73727(Converter):
         raise PostponedImplementationError('No recognizable matrices.')
 
 
-def link_static_matrix_files():
-    for bundle in static_prod_bundles:
-        src_dir = Path('projects') / bundle
-        link_project_metadata(str(src_dir), file_pattern='*.mtx.zip')
-        print(f'Hard-linked project ("*.mtx.zip" only) contents: {bundle}/hca to {bundle}/bundle.')
-
-
 def main(project_dirs: List[Path]):
     not_implemented_projects = []
     failed_projects = []
@@ -1802,7 +1794,7 @@ def main(project_dirs: List[Path]):
         print_projects('failed', failed_projects, file=sys.stderr)
         print_projects('succeeded', succeeded_projects)
 
-    link_static_matrix_files()
+    populate_all_static_projects(file_pattern='*.mtx.zip')
 
 
 def print_projects(title, projects, file=None):

--- a/convert_matrices.py
+++ b/convert_matrices.py
@@ -1794,8 +1794,8 @@ def main(project_dirs: List[Path]):
 
     for bundle in static_prod_bundles:
         src_dir = Path('projects') / bundle
-        print(f'Hard-linked project ("*.mtx.zip" only) contents: {bundle}/hca to {bundle}/bundle.')
         link_project_metadata(str(src_dir), file_pattern='*.mtx.zip')
+        print(f'Hard-linked project ("*.mtx.zip" only) contents: {bundle}/hca to {bundle}/bundle.')
 
     print_projects('not implemented', not_implemented_projects, file=sys.stderr)
     print_projects('failed', failed_projects, file=sys.stderr)

--- a/convert_matrices.py
+++ b/convert_matrices.py
@@ -1764,6 +1764,13 @@ class GSE73727(Converter):
         raise PostponedImplementationError('No recognizable matrices.')
 
 
+def link_static_matrix_files():
+    for bundle in static_prod_bundles:
+        src_dir = Path('projects') / bundle
+        link_project_metadata(str(src_dir), file_pattern='*.mtx.zip')
+        print(f'Hard-linked project ("*.mtx.zip" only) contents: {bundle}/hca to {bundle}/bundle.')
+
+
 def main(project_dirs: List[Path]):
     not_implemented_projects = []
     failed_projects = []
@@ -1791,15 +1798,11 @@ def main(project_dirs: List[Path]):
         else:
             for class_name, class_obj in converter_classes.items():
                 log.warning('Unused converter `%s` with UUID `%s`', class_obj.__doc__.strip())
+        print_projects('not implemented', not_implemented_projects, file=sys.stderr)
+        print_projects('failed', failed_projects, file=sys.stderr)
+        print_projects('succeeded', succeeded_projects)
 
-    for bundle in static_prod_bundles:
-        src_dir = Path('projects') / bundle
-        link_project_metadata(str(src_dir), file_pattern='*.mtx.zip')
-        print(f'Hard-linked project ("*.mtx.zip" only) contents: {bundle}/hca to {bundle}/bundle.')
-
-    print_projects('not implemented', not_implemented_projects, file=sys.stderr)
-    print_projects('failed', failed_projects, file=sys.stderr)
-    print_projects('succeeded', succeeded_projects)
+    link_static_matrix_files()
 
 
 def print_projects(title, projects, file=None):

--- a/copy_static_project.py
+++ b/copy_static_project.py
@@ -1,0 +1,22 @@
+import os
+import glob
+import shutil
+
+
+def link_project_metadata(project_dir, file_pattern='*.json'):
+    assert os.path.isdir(project_dir)
+    assert len(os.path.basename(project_dir)) == len('4a95101c-9ffc-4f30-a809-f04518a23803')
+    bundle_dir = os.path.join(project_dir, 'bundle')
+    hca_dir = os.path.join(project_dir, 'hca')
+
+    if os.path.exists(hca_dir):
+        if os.path.exists(bundle_dir):
+            shutil.rmtree(bundle_dir)
+
+        os.mkdir(bundle_dir)
+
+        for filename in glob.glob(os.path.join(hca_dir, file_pattern)):
+            new_filename = os.path.join(bundle_dir, os.path.basename(filename))
+            os.link(filename, new_filename)
+    else:
+        raise RuntimeError(f'{hca_dir} does not exist.  Nothing to link over.')

--- a/copy_static_project.py
+++ b/copy_static_project.py
@@ -1,22 +1,38 @@
 import os
 import glob
-import shutil
+from pathlib import Path
 
 
-def link_project_metadata(project_dir, file_pattern='*.json'):
-    assert os.path.isdir(project_dir)
-    assert len(os.path.basename(project_dir)) == len('4a95101c-9ffc-4f30-a809-f04518a23803')
-    bundle_dir = os.path.join(project_dir, 'bundle')
-    hca_dir = os.path.join(project_dir, 'hca')
+def populate_static_project(project_dir: Path, file_pattern: str = '*.json'):
+    assert project_dir.is_dir()
+    assert len(project_dir.name) == len('4a95101c-9ffc-4f30-a809-f04518a23803')
+    bundle_dir = project_dir / 'bundle'
+    hca_dir = project_dir / 'hca'
 
-    if os.path.exists(hca_dir):
-        if os.path.exists(bundle_dir):
-            shutil.rmtree(bundle_dir)
+    if hca_dir.is_dir():
+        if not bundle_dir.is_dir():
+            os.mkdir(str(bundle_dir))
 
-        os.mkdir(bundle_dir)
+        print(f'Removing old {file_pattern} files from: {bundle_dir}')
+        for filename in glob.glob(str(bundle_dir / file_pattern)):
+            new_filename = str(bundle_dir / os.path.basename(filename))
+            os.unlink(new_filename)
 
-        for filename in glob.glob(os.path.join(hca_dir, file_pattern)):
-            new_filename = os.path.join(bundle_dir, os.path.basename(filename))
+        print(f'Populating new {file_pattern} files into: {bundle_dir}')
+        for filename in glob.glob(str(hca_dir / file_pattern)):
+            new_filename = str(bundle_dir / os.path.basename(filename))
             os.link(filename, new_filename)
     else:
         raise RuntimeError(f'{hca_dir} does not exist.  Nothing to link over.')
+
+
+def populate_all_static_projects(file_pattern='*.json'):
+    for root, dirs, files in os.walk('projects'):
+        for project_uuid in dirs:
+            if len(project_uuid) == len('4a95101c-9ffc-4f30-a809-f04518a23803'):
+                src_dir = Path('projects') / project_uuid
+                hca_dir = src_dir / 'hca'
+                if hca_dir.is_dir():
+                    populate_static_project(src_dir, file_pattern=file_pattern)
+                    print(f'Hard-linked project ("{file_pattern}" only) contents: '
+                          f'{project_uuid}/hca to {project_uuid}/bundle.')

--- a/copy_static_project.py
+++ b/copy_static_project.py
@@ -26,7 +26,7 @@ def populate_static_project(project_dir: Path, file_pattern: str = '*.json'):
         raise RuntimeError(f'{hca_dir} does not exist.  Nothing to link over.')
 
 
-def populate_all_static_projects(file_pattern='*.json'):
+def populate_all_static_projects(file_pattern: str = '*.json'):
     for root, dirs, files in os.walk('projects'):
         for project_uuid in dirs:
             if len(project_uuid) == len('4a95101c-9ffc-4f30-a809-f04518a23803'):

--- a/copy_static_project.py
+++ b/copy_static_project.py
@@ -1,11 +1,13 @@
 import os
+import re
 import glob
 from pathlib import Path
 
+UUID_PATTERN = "[a-z0-9]{8}-[a-z0-9]{4}-[a-z0-9]{4}-[a-z0-9]{4}-[a-z0-9]{12}"
+UUID_REGEX = re.compile(UUID_PATTERN)
+
 
 def populate_static_project(project_dir: Path, file_pattern: str = '*.json'):
-    assert project_dir.is_dir()
-    assert len(project_dir.name) == len('4a95101c-9ffc-4f30-a809-f04518a23803')
     bundle_dir = project_dir / 'bundle'
     hca_dir = project_dir / 'hca'
 
@@ -22,17 +24,11 @@ def populate_static_project(project_dir: Path, file_pattern: str = '*.json'):
         for filename in glob.glob(str(hca_dir / file_pattern)):
             new_filename = str(bundle_dir / os.path.basename(filename))
             os.link(filename, new_filename)
-    else:
-        raise RuntimeError(f'{hca_dir} does not exist.  Nothing to link over.')
 
 
 def populate_all_static_projects(file_pattern='*.json'):
     for root, dirs, files in os.walk('projects'):
-        for project_uuid in dirs:
-            if len(project_uuid) == len('4a95101c-9ffc-4f30-a809-f04518a23803'):
-                src_dir = Path('projects') / project_uuid
-                hca_dir = src_dir / 'hca'
-                if hca_dir.is_dir():
-                    populate_static_project(src_dir, file_pattern=file_pattern)
-                    print(f'Hard-linked project ("{file_pattern}" only) contents: '
-                          f'{project_uuid}/hca to {project_uuid}/bundle.')
+        for dir_name in dirs:
+            if UUID_REGEX.match(dir_name):
+                project_dir = Path('projects') / dir_name
+                populate_static_project(project_dir=project_dir, file_pattern=file_pattern)

--- a/generate_metadata.py
+++ b/generate_metadata.py
@@ -19,6 +19,8 @@ from create_project import (
     get_spreadsheet_paths,
     run,
 )
+from copy_static_project import link_project_metadata
+
 
 for sub_dir in 'existing', 'new':
     src_dir = Path('spreadsheets') / sub_dir
@@ -26,4 +28,44 @@ for sub_dir in 'existing', 'new':
     for i, project in enumerate(projects):
         print(f'\n% Progress: {i + 1}/{len(projects)} projects ({project}).\n'
               f'===========================================================')
-        run(xlsx=project.as_posix())
+        run(xlsx=str(project))
+
+
+# This will work with:
+# for root, dirs, files in os.walk('/home/quokka/yeah/load-project/projects'):
+#     for d in dirs:
+#         if len(d) == len('4a95101c-9ffc-4f30-a809-f04518a23803'):
+# But I think the explicit list is clearer and strictly avoids possible collisions
+
+# TODO: These have no excel sheets... though in theory Will has them and they should be used instead.
+static_prod_bundles = [
+    '1defdada-a365-44ad-9b29-443b06bd11d6',
+    '4a95101c-9ffc-4f30-a809-f04518a23803',
+    '4e6f083b-5b9a-4393-9890-2a83da8188f1',
+    '005d611a-14d5-4fbf-846e-571a1f874f70',
+    '8c3c290d-dfff-4553-8868-54ce45f4ba7f',
+    '008e40e8-66ae-43bb-951c-c073a2fa6774',
+    '9c20a245-f2c0-43ae-82c9-2232ec6b594f',
+    '027c51c6-0719-469f-a7f5-640fe57cbece',
+    '74b6d569-3b11-42ef-b6b1-a0454522b4a0',
+    '88ec040b-8705-4f77-8f41-f81e57632f7d',
+    '091cf39b-01bc-42e5-9437-f419a66c8a45',
+    '577c946d-6de5-4b55-a854-cd3fde40bff2',
+    '116965f3-f094-4769-9d28-ae675c1b569c',
+    '8185730f-4113-40d3-9cc3-929271784c2b',
+    'a9c022b4-c771-4468-b769-cabcf9738de3',
+    'a29952d9-925e-40f4-8a1c-274f118f1f51',
+    'abe1a013-af7a-45ed-8c26-f3793c24a1f4',
+    'ae71be1d-ddd8-4feb-9bed-24c3ddb6e1ad',
+    'c4077b3c-5c98-4d26-a614-246d12c2e5d7',
+    'cc95ff89-2e68-4a08-a234-480eca21ce79',
+    'e0009214-c0a0-4a7b-96e2-d6a83e966ce0',
+    'f81efc03-9f56-4354-aabb-6ce819c3d414',
+    'f83165c5-e2ea-4d15-a5cf-33f3550bffde'
+]
+
+for bundle in static_prod_bundles:
+    src_dir = Path('projects') / bundle
+    link_project_metadata(str(src_dir), file_pattern='*.json')
+    print(f'Hard-linked project ("*.json" only) contents: {bundle}/hca to {bundle}/bundle.')
+    link_project_metadata(str(src_dir), file_pattern='*.mtx.zip')

--- a/generate_metadata.py
+++ b/generate_metadata.py
@@ -13,8 +13,7 @@ also have slightly different formatting (all seem to be missing a "funders" sect
 Editing 'upload=False' to 'upload=True' with upload to dss dev if you are credentialed to do so.
 Otherwise it will just parse the excel files and generate all of the matrix and json files necessary for upload.
 """
-from pathlib import Path
-from copy_static_project import link_project_metadata
+from copy_static_project import populate_all_static_projects
 from create_project import (
     run,
 )
@@ -28,41 +27,4 @@ for i, xlsx in enumerate(xlsxs):
           f'===========================================================')
     run(xlsx=str(xlsx))
 
-# This will work with:
-# for root, dirs, files in os.walk('/home/quokka/yeah/load-project/projects'):
-#     for d in dirs:
-#         if len(d) == len('4a95101c-9ffc-4f30-a809-f04518a23803'):
-# But I think the explicit list is clearer and strictly avoids possible collisions
-
-# TODO: These have no excel sheets... though in theory Will has them and they should be used instead.
-static_prod_bundles = [
-    '1defdada-a365-44ad-9b29-443b06bd11d6',
-    '4a95101c-9ffc-4f30-a809-f04518a23803',
-    '4e6f083b-5b9a-4393-9890-2a83da8188f1',
-    '005d611a-14d5-4fbf-846e-571a1f874f70',
-    '8c3c290d-dfff-4553-8868-54ce45f4ba7f',
-    '008e40e8-66ae-43bb-951c-c073a2fa6774',
-    '9c20a245-f2c0-43ae-82c9-2232ec6b594f',
-    '027c51c6-0719-469f-a7f5-640fe57cbece',
-    '74b6d569-3b11-42ef-b6b1-a0454522b4a0',
-    '88ec040b-8705-4f77-8f41-f81e57632f7d',
-    '091cf39b-01bc-42e5-9437-f419a66c8a45',
-    '577c946d-6de5-4b55-a854-cd3fde40bff2',
-    '116965f3-f094-4769-9d28-ae675c1b569c',
-    '8185730f-4113-40d3-9cc3-929271784c2b',
-    'a9c022b4-c771-4468-b769-cabcf9738de3',
-    'a29952d9-925e-40f4-8a1c-274f118f1f51',
-    'abe1a013-af7a-45ed-8c26-f3793c24a1f4',
-    'ae71be1d-ddd8-4feb-9bed-24c3ddb6e1ad',
-    'c4077b3c-5c98-4d26-a614-246d12c2e5d7',
-    'cc95ff89-2e68-4a08-a234-480eca21ce79',
-    'e0009214-c0a0-4a7b-96e2-d6a83e966ce0',
-    'f81efc03-9f56-4354-aabb-6ce819c3d414',
-    'f83165c5-e2ea-4d15-a5cf-33f3550bffde'
-]
-
-for bundle in static_prod_bundles:
-    src_dir = Path('projects') / bundle
-    link_project_metadata(str(src_dir), file_pattern='*.json')
-    print(f'Hard-linked project ("*.json" only) contents: {bundle}/hca to {bundle}/bundle.')
-    # link_project_metadata(str(src_dir), file_pattern='*.mtx.zip')
+populate_all_static_projects(file_pattern='*.json')

--- a/generate_metadata.py
+++ b/generate_metadata.py
@@ -65,4 +65,4 @@ for bundle in static_prod_bundles:
     src_dir = Path('projects') / bundle
     link_project_metadata(str(src_dir), file_pattern='*.json')
     print(f'Hard-linked project ("*.json" only) contents: {bundle}/hca to {bundle}/bundle.')
-    link_project_metadata(str(src_dir), file_pattern='*.mtx.zip')
+    # link_project_metadata(str(src_dir), file_pattern='*.mtx.zip')


### PR DESCRIPTION
I put unused files into `.attic` as a record of how some things were parsed.  These can be safely ignored, I simply want them as a record to reproduce this work in the future.  Particularly the `prod_cell_counts.json`.

Bundles will be static and uploaded into the remote instance, then linked though when the appropriate make commands are run.